### PR TITLE
Fix command pkngutil->pkgutil

### DIFF
--- a/src/mopup/__init__.py
+++ b/src/mopup/__init__.py
@@ -42,7 +42,7 @@ def choicechanges(pkgfile: str) -> str:
     all_installed = set(
         run(  # noqa: S603
             [
-                "/usr/sbin/pkngutil",
+                "/usr/sbin/pkgutil",
                 "--pkgs",
             ],
             stdout=PIPE,


### PR DESCRIPTION
Fixes https://github.com/glyph/MOPUp/issues/346#issuecomment-2277789471.

After:

```console
❯ python3.13 --version
Python 3.13.0b4

❯ python3.13t --version
Python 3.13.0b4
```
```console
❯ python3.13 -m mopup
this version: 3.13.0b4; new version: 3.13.0rc1
update needed from https://www.python.org/ftp/python/3.13.0/python-3.13.0rc1-macos11.pkg
Downloading python-3.13.0rc1-macos11.pkg... ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
.
selecting choice org.python.Python.PythonFramework-3.13
selecting choice org.python.Python.PythonApplications-3.13
selecting choice org.python.Python.PythonUnixTools-3.13
selecting choice org.python.Python.PythonDocumentation-3.13
selecting choice org.python.Python.PythonTFramework-3.13
Enter your administrative password to run the update:
Password:
installer: Package name is Python
installer: choices changes file '/var/folders/c8/hl_96fcs0hjgr29njx33x20c0000gn/T/tmpe97208zf.plist' applied
installer: Upgrading at base path /
installer: The upgrade was successful.
Complete.
```
```console
❯ python3.13 --version
Python 3.13.0rc1

❯ python3.13t --version
Python 3.13.0rc1
