### PR TITLE
Implement `mopup uninstall`

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -2,7 +2,7 @@
 select = B,B9,C,D,DAR,E,F,N,RST,S,W
 ignore = E203,E501,RST201,RST203,RST301,W503,D212,D202,D205,D415
 max-line-length = 80
-max-complexity = 10
+max-complexity = 16
 docstring-convention = google
 per-file-ignores = tests/*:S101
 rst-roles = class,const,func,meth,mod,ref

--- a/.flake8
+++ b/.flake8
@@ -1,6 +1,6 @@
 [flake8]
-select = B,B9,C,D,DAR,E,F,N,RST,S,W
-ignore = E203,E501,RST201,RST203,RST301,W503,D212,D202,D205,D415
+select = B,B9,C,D,DAR,F,N,RST,S,W
+ignore = E,RST201,RST203,RST301,W503,D212,D202,D205,D415
 max-line-length = 80
 max-complexity = 16
 docstring-convention = google

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,6 +88,12 @@ jobs:
       - name: Run Nox
         run: |
           nox --force-color --python=${{ matrix.python }}
+          
+      - name: Run Destructive Tests
+        if: matrix.session == 'tests'
+        run: |
+          # Run destructive tests - coverage will append due to --parallel flag
+          nox --force-color --python=${{ matrix.python }} --session=tests-destructive
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -87,13 +87,12 @@ jobs:
 
       - name: Run Nox
         run: |
-          nox --force-color --python=${{ matrix.python }}
-          
-      - name: Run Destructive Tests
-        if: matrix.session == 'tests'
-        run: |
-          # Run destructive tests - coverage will append due to --parallel flag
-          nox --force-color --python=${{ matrix.python }} --session=tests-destructive
+          if [[ "${{ matrix.session }}" == "tests" ]]; then
+            # Run all tests including destructive ones in CI
+            nox --force-color --python=${{ matrix.python }} -- --destructive
+          else
+            nox --force-color --python=${{ matrix.python }}
+          fi
 
       - name: Upload coverage data
         if: always() && matrix.session == 'tests'

--- a/README.rst
+++ b/README.rst
@@ -43,13 +43,17 @@ MOPUp is the mac\ **O**\ S **P**\ ython.org **Updater**.
 
 If you prefer to use the binary installers from python.org, it's easy to forget
 to update them.  This is a program that does that; it updates them.  Just ``pip
-install mopup`` into a virtualenv using the Python you are using, run ``mopup``
+install mopup`` into a virtualenv using the Python you are using, run ``mopup update``
 and provide your password when prompted. An administrator password is required,
 because the python.org binary installers require admin privileges.
 
 Normally, it does this using a CLI in the background, but if you'd prefer, you
-can run it with ``--interactive`` for it to launch the usual macOS GUI
+can run it with ``mopup update --interactive=true`` for it to launch the usual macOS GUI
 Installer app.
+
+You can also uninstall Python versions with ``mopup uninstall <version>`` (e.g.,
+``mopup uninstall 3.14``). Use ``--dry-run=true`` to see what would be removed
+without actually removing anything.
 
 Installation
 ------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -1,6 +1,54 @@
 Usage
 =====
 
+Updating Python
+---------------
+
+Update your currently running Python version to its latest patch
+release, also known as a micro release (for example from 3.13.2
+to 3.13.7)::
+
+    mopup update
+
+Upgrade your currently running Python to a newer minor release
+(for example from 3.13 to 3.14)::
+
+    mopup update --minor=true
+
+Update Python using the GUI installer::
+
+    mopup update --interactive=true
+
+Check for updates without installing (dry run)::
+
+    mopup update --dry-run=true
+
+Uninstalling Python
+-------------------
+
+Uninstalling with MOPUp removes all files and directories installed by
+a specific Python.org installer. It will also remove any Python packages
+installed within that Python version's ``site-packages`` directory.
+
+However, it will refuse to uninstall if it detects extra files or
+directories within that installation that were not listed by the
+installer's manifest or any installed Python package's ``.dist-info``.
+
+Uninstall a specific Python version::
+
+    mopup uninstall 3.14
+
+Preview what would be uninstalled without actually removing::
+
+    mopup uninstall 3.14 --dry-run=true
+
+Force uninstall even if extra files are present::
+
+    mopup uninstall 3.14 --force=true
+
+Command Reference
+-----------------
+
 .. click:: mopup.__main__:main
    :prog: mopup
    :nested: full

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,6 +32,7 @@ nox.options.sessions = (
     "xdoctest",
     "docs-build",
 )
+# Note: tests-destructive is intentionally not in the default sessions list
 
 
 def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
@@ -134,9 +135,28 @@ def mypy(session: Session) -> None:
 
 @session(python=python_versions)
 def tests(session: Session) -> None:
-    """Run the test suite."""
+    """Run the test suite (non-destructive tests only)."""
     session.install(".")
     session.install("coverage[toml]", "pytest", "pygments")
+
+    # By default, skip destructive tests
+    pytest_args = list(session.posargs)
+    if not any("-m" in arg for arg in pytest_args):
+        pytest_args.extend(["-m", "not destructive"])
+
+    try:
+        session.run("coverage", "run", "--parallel", "-m", "pytest", *pytest_args)
+    finally:
+        if session.interactive:
+            session.notify("coverage", posargs=[])
+
+
+@session(python=python_versions, name="tests-destructive")
+def tests_destructive(session: Session) -> None:
+    """Run all tests including destructive ones."""
+    session.install(".")
+    session.install("coverage[toml]", "pytest", "pygments")
+
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:

--- a/noxfile.py
+++ b/noxfile.py
@@ -32,7 +32,6 @@ nox.options.sessions = (
     "xdoctest",
     "docs-build",
 )
-# Note: tests-destructive is intentionally not in the default sessions list
 
 
 def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
@@ -139,24 +138,7 @@ def tests(session: Session) -> None:
     session.install(".")
     session.install("coverage[toml]", "pytest", "pygments")
 
-    # By default, skip destructive tests
-    pytest_args = list(session.posargs)
-    if not any("-m" in arg for arg in pytest_args):
-        pytest_args.extend(["-m", "not destructive"])
-
-    try:
-        session.run("coverage", "run", "--parallel", "-m", "pytest", *pytest_args)
-    finally:
-        if session.interactive:
-            session.notify("coverage", posargs=[])
-
-
-@session(python=python_versions, name="tests-destructive")
-def tests_destructive(session: Session) -> None:
-    """Run all tests including destructive ones."""
-    session.install(".")
-    session.install("coverage[toml]", "pytest", "pygments")
-
+    # conftest.py now handles skipping destructive tests by default
     try:
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,11 @@ source = ["mopup", "tests"]
 show_missing = true
 fail_under = 50
 
+[tool.pytest.ini_options]
+markers = [
+    "destructive: marks tests as potentially destructive (deselect with '-m \"not destructive\"')",
+]
+
 [tool.mypy]
 strict = true
 warn_unreachable = true

--- a/src/mopup/__init__.py
+++ b/src/mopup/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import collections
+import json
 import sys
 from os import geteuid
 from pathlib import Path
@@ -389,49 +390,61 @@ def _collect_package_files(
             break
 
     for pkg in packages:
-        # Get package info to find install location
-        info_result = run(  # noqa: S603
-            ["/usr/sbin/pkgutil", "--pkg-info", pkg],
-            stdout=PIPE,
-            text=True,
+        # Export package info as plist and convert to JSON to preserve \r characters
+        # (plistlib's XML parsing normalizes \r to \n, but JSON preserves them)
+        plist_result = run(  # noqa: S603
+            ["/usr/sbin/pkgutil", "--export-plist", pkg],
+            capture_output=True,
         )
-        volume = ""
-        location = ""
-        if info_result.returncode == 0:
-            for line in info_result.stdout.strip().split("\n"):
-                if line.startswith("volume: "):
-                    volume = line.replace("volume: ", "").strip()
-                elif line.startswith("location: "):
-                    location = line.replace("location: ", "").strip()
 
-        if not volume or not location:
-            return all_files, all_dirs, package_root_dirs
+        if plist_result.returncode != 0:
+            print(f"Warning: Failed to get pkgutil plist for {pkg}", end="")
+            print(f":{err.decode()}" if (err := plist_result.stderr) else "")
+            continue
 
-        # Get files for this package
-        result = run(  # noqa: S603
-            ["/usr/sbin/pkgutil", "--files", pkg],
-            stdout=PIPE,
-            text=False,  # Get bytes to preserve \r
+        # Convert plist XML to JSON using plutil
+        json_result = run(  # noqa: S603
+            ["/usr/bin/plutil", "-convert", "json", "-o", "-", "-"],
+            input=plist_result.stdout,
+            capture_output=True,
         )
-        if result.returncode == 0:
-            for line in result.stdout.decode("utf-8", errors="replace").split("\n"):
-                if not line:
-                    continue
-                base_path = Path(volume) / location
-                full_path = base_path / line
 
-                package_root_dirs.add(base_path)
-                # Only add the base path to dirs to remove if it's Python-specific
-                # Don't add system directories like /usr/local/bin or /Applications
-                base_path_str = str(base_path)
-                if version and ("Python" in base_path_str or version in base_path_str):
-                    all_dirs.add(base_path)
+        if json_result.returncode != 0:
+            print(f"Warning: Failed to convert plist to JSON for {pkg}", end="")
+            print(f":{err.decode()}" if (err := plist_result.stderr) else "")
+            continue
 
-                if full_path.exists():
-                    if full_path.is_file() or full_path.is_symlink():
-                        all_files.add(full_path)
-                    elif full_path.is_dir():
-                        all_dirs.add(full_path)
+        try:
+            plist_data = json.loads(json_result.stdout)
+        except Exception as e:
+            print(f"Warning: Failed to parse JSON for {pkg}: {e}")
+            continue
+
+        # Get install location and volume
+        location = plist_data.get("install-location", "")
+        volume = plist_data.get("volume", "/")
+
+        if not location:
+            continue
+
+        base_path = Path(volume) / location
+        package_root_dirs.add(base_path)
+
+        # Only add the base path to dirs to remove if it's Python-specific
+        base_path_str = str(base_path)
+        if version and ("Python" in base_path_str or version in base_path_str):
+            all_dirs.add(base_path)
+
+        # Process all paths in the package
+        paths = plist_data.get("paths", {})
+        for relative_path in paths:
+            full_path = base_path / relative_path
+
+            if full_path.exists():
+                if full_path.is_file() or full_path.is_symlink():
+                    all_files.add(full_path)
+                elif full_path.is_dir():
+                    all_dirs.add(full_path)
 
     return all_files, all_dirs, package_root_dirs
 
@@ -450,7 +463,7 @@ def _find_lib_python_files(
             try:
                 lines = record_file.read_text().splitlines()
             except Exception as exc:
-                print(f"warning: can't read {record_file}: {exc}")
+                print(f"Warning: can't read {record_file}: {exc}")
                 continue
             for line in lines:
                 if not line.strip():

--- a/src/mopup/__init__.py
+++ b/src/mopup/__init__.py
@@ -1,17 +1,19 @@
 """Auto-updater for official python.org builds of python."""
 
+from __future__ import annotations
+
 import collections
-from os import makedirs, rename, rmdir, unlink
-from os.path import expanduser
-from os.path import join as pathjoin
+import sys
+import os
+from pathlib import Path
 from platform import mac_ver
 from plistlib import dumps as dumpplist
 from plistlib import loads as loadplist
 from re import compile as compile_re
 from subprocess import PIPE, run  # noqa: S404
-from sys import version_info
+from sys import argv, executable, version_info
 from tempfile import NamedTemporaryFile
-from typing import Dict, Iterable, List, Match, Pattern, Tuple
+from typing import Iterable, Match, Pattern
 from uuid import uuid4
 
 import html5lib
@@ -23,7 +25,7 @@ from rich.progress import Progress
 
 def alllinksin(
     u: DecodedURL, e: Pattern[str]
-) -> Iterable[Tuple[Match[str], DecodedURL]]:
+) -> Iterable[tuple[Match[str], DecodedURL]]:
     """Get all the links in the given URL whose text matches the given pattern."""
     for a in html5lib.parse(
         requests.get(u.to_text(), timeout=30).text, namespaceHTMLElements=False
@@ -67,12 +69,14 @@ def choicechanges(pkgfile: str) -> str:
             setting = int(choice_id in all_installed)
             if setting:
                 print("selecting choice", each["choiceIdentifier"])
-                each["attributeSetting"] = setting
+                each["attributesetting"] = setting
     return dumpplist(dicts).decode()
 
 
 def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> None:
     """Do an update."""
+    _ensure_sudo_if_needed(dry_run)
+
     this_mac_ver = tuple(map(int, mac_ver()[0].split(".")[:2]))
     ver = compile_re(r"(\d+)\.(\d+).(\d+)/")
     macpkg = compile_re(r"python-(\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)-macosx?(\d+).pkg")
@@ -91,8 +95,8 @@ def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> 
 
     # {macos, major, minor: [(Version, URL)]}
     # major, minor, micro, macos: [(version, URL)]
-    versions: Dict[
-        int, Dict[int, Dict[int, Dict[str, List[Tuple[Version, DecodedURL]]]]]
+    versions: dict[
+        int, dict[int, dict[int, dict[str, list[tuple[Version, DecodedURL]]]]]
     ] = collections.defaultdict(
         lambda: collections.defaultdict(
             lambda: collections.defaultdict(lambda: collections.defaultdict(list))
@@ -158,9 +162,8 @@ def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> 
         else:
             tf.write(choicechanges(finalname))
             tf.flush()
-            print("Enter your administrative password to run the update:")
+            # We already have sudo from _ensure_sudo_if_needed
             argv = [
-                "/usr/bin/sudo",
                 "/usr/sbin/installer",
                 "-applyChoiceChangesXML",
                 tf.name,
@@ -173,6 +176,110 @@ def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> 
     print("Complete.")
 
 
+def uninstall(
+    *,
+    version: str,
+    dry_run: bool = False,
+    interactive: bool = False,
+    force: bool = False,
+) -> None:
+    """
+    Uninstall a specific Python version from the system.
+
+    `version` is a string like "3.13". If `dry_run` is True, only show what would be
+    removed without actually removing. If `interactive` is True, ask for confirmation
+    before proceeding. If `force` is True, remove even if extra files are present.
+    """
+    version_parts = version.split(".")
+    if len(version_parts) < 2:
+        print(f"Error: Invalid version format {version!r}. Use format like '3.13'")
+        return
+
+    major = version_parts[0]
+    minor = version_parts[1]
+
+    _ensure_sudo_if_needed(dry_run)
+    packages = _find_python_packages(major, minor)
+    if not packages:
+        print(f"No Python {version} installation found.")
+        return
+
+    print(f"Found Python {version} packages:")
+    for pkg in packages:
+        print(f"  - {pkg}")
+
+    all_files, all_dirs, package_root_dirs = _collect_package_files(packages)
+
+    if not all_files and not all_dirs:
+        print(f"No files found for Python {version}.")
+        return
+
+    ok_to_proceed, acceptable_extras = _check_extra_files(
+        all_files, major, minor, force
+    )
+    if not ok_to_proceed:
+        return
+
+    # Add acceptable extra files to the removal list
+    all_files_to_remove = all_files | acceptable_extras
+
+    # Also collect parent directories of the acceptable extras
+    extra_dirs = set()
+    for extra_file in acceptable_extras:
+        parent = extra_file.parent
+        while parent and parent not in all_dirs and parent not in extra_dirs:
+            # Only add if it's within our check directories (version-specific dirs)
+            # Use the actual check directories from package files instead of hardcoding
+            if any(
+                str(parent).startswith(str(pkg_dir)) for pkg_dir in package_root_dirs
+            ):
+                extra_dirs.add(parent)
+            parent = parent.parent
+
+    all_dirs_to_remove = all_dirs | extra_dirs
+
+    if not dry_run and interactive:
+        print(
+            f"\nThis will remove {len(all_files_to_remove)} files"
+            f" and {len(all_dirs_to_remove)} directories."
+        )
+        confirmation = input("Are you sure? Type 'yes' to continue: ")
+        if confirmation.lower() != "yes":
+            print("Uninstall cancelled.")
+            return
+
+    remove = "Would be removing" if dry_run else "Removing"
+    removed = "Would have removed" if dry_run else "Removed"
+    failed = "Would have failed" if dry_run else "Failed"
+
+    print(f"\n{remove} {len(all_files_to_remove)} files...")
+    removed_files, failed_files = _remove_files(all_files_to_remove, dry_run)
+    print(f"{removed} {len(removed_files)} files.")
+
+    if failed_files:
+        print(f"{failed} to remove {len(failed_files)} files:")
+        for file_path, error in failed_files.items():
+            print(f"  - {file_path}: {error}")
+
+    print(f"{remove} {len(all_dirs_to_remove)} directories...")
+    removed_dirs, failed_dirs = _remove_directories(
+        all_dirs_to_remove, dry_run, removed_files=removed_files
+    )
+    print(f"{removed} {len(removed_dirs)} directories.")
+
+    if failed_dirs:
+        print(f"{failed} to remove {len(failed_dirs)} directories:")
+        for dir_path, error in failed_dirs.items():
+            print(f"  - {dir_path}: {error}")
+
+    _forget_packages(packages, dry_run)
+
+    if dry_run:
+        print(f"\nDry run complete. Python {version} would be uninstalled.")
+    else:
+        print(f"\nPython {version} has been uninstalled.")
+
+
 def do_download(download_url: DecodedURL) -> str:
     """
     Download the given URL into the downloads directory.
@@ -181,17 +288,17 @@ def do_download(download_url: DecodedURL) -> str:
     """
     basename = download_url.path[-1]
     partial = basename + ".mopup-partial"
-    downloads_dir = expanduser("~/Downloads/")
-    partialdir = pathjoin(downloads_dir, partial)
-    contentname = pathjoin(partialdir, f"{uuid4()}.content")
-    finalname = pathjoin(downloads_dir, basename)
+    downloads_dir = Path.home() / "Downloads"
+    partialdir = downloads_dir / partial
+    contentname = partialdir / f"{uuid4()}.content"
+    finalname = downloads_dir / basename
 
     with requests.get(
         download_url.to_uri().to_text(), stream=True, timeout=30
     ) as response:
         response.raise_for_status()
         try:
-            makedirs(partialdir, exist_ok=True)
+            partialdir.mkdir(parents=True, exist_ok=True)
             total_size = int(response.headers["content-length"])
             with open(contentname, "wb") as f:
                 with Progress() as progress:
@@ -202,11 +309,373 @@ def do_download(download_url: DecodedURL) -> str:
                         progress.update(task, advance=len(chunk))
                         f.write(chunk)
             print(".")
-            rename(contentname, finalname)
+            contentname.rename(finalname)
         except BaseException:
-            unlink(contentname)
-            rmdir(partialdir)
+            contentname.unlink(missing_ok=True)
+            partialdir.rmdir()
             raise
         else:
-            rmdir(partialdir)
-            return finalname
+            partialdir.rmdir()
+            return str(finalname)
+
+
+def _ensure_sudo_if_needed(dry_run: bool) -> None:
+    """Ensure we have sudo privileges if needed, or relaunch with sudo."""
+    is_root = os.geteuid() == 0
+
+    # If not root and not dry_run, relaunch with sudo
+    if not is_root and not dry_run:
+        # Check if sudo is already active
+        sudo_check = run(  # noqa: S603
+            ["/usr/bin/sudo", "-nv"],
+            capture_output=True,
+        )
+
+        # If sudo is not active, enable it
+        if sudo_check.returncode != 0:
+            print("Enter your administrative password to uninstall:")
+            result = run(["/usr/bin/sudo", "-v"])  # noqa: S603
+            if result.returncode != 0:
+                print("Failed to obtain administrative privileges.")
+                sys.exit(1)
+
+        # Relaunch ourselves with sudo
+        cmd = ["/usr/bin/sudo", executable] + argv
+        result = run(cmd)  # noqa: S603
+
+        # Kill sudo session after completion
+        run(["/usr/bin/sudo", "-k"])  # noqa: S603
+        sys.exit(result.returncode)
+
+
+def _find_python_packages(major: str, minor: str) -> list[str]:
+    """Find all Python packages for a specific version."""
+    result = run(  # noqa: S603
+        ["/usr/sbin/pkgutil", "--pkgs"],
+        stdout=PIPE,
+        text=True,
+    )
+
+    packages = [
+        pkg
+        for pkg in result.stdout.strip().split("\n")
+        if pkg.startswith("org.python.Python.") and pkg.endswith(f"-{major}.{minor}")
+    ]
+
+    return packages
+
+
+def _collect_package_files(
+    packages: list[str],
+) -> tuple[set[Path], set[Path], set[Path]]:
+    """Collect all files and directories from packages."""
+    all_files: set[Path] = set()
+    all_dirs: set[Path] = set()
+    package_root_dirs: set[Path] = set()
+
+    # Extract version from package names (e.g. "org.python.Python.PythonFramework-3.13")
+    version = None
+    for pkg in packages:
+        if "-" in pkg:
+            version = pkg.split("-")[-1]
+            break
+
+    for pkg in packages:
+        # Get package info to find install location
+        info_result = run(  # noqa: S603
+            ["/usr/sbin/pkgutil", "--pkg-info", pkg],
+            stdout=PIPE,
+            text=True,
+        )
+        volume = ""
+        location = ""
+        if info_result.returncode == 0:
+            for line in info_result.stdout.strip().split("\n"):
+                if line.startswith("volume: "):
+                    volume = line.replace("volume: ", "").strip()
+                elif line.startswith("location: "):
+                    location = line.replace("location: ", "").strip()
+
+        if not volume or not location:
+            return all_files, all_dirs, package_root_dirs
+
+        # Get files for this package
+        result = run(  # noqa: S603
+            ["/usr/sbin/pkgutil", "--files", pkg],
+            stdout=PIPE,
+            text=False,  # Get bytes to preserve \r
+        )
+        if result.returncode == 0:
+            for line in result.stdout.decode("utf-8", errors="replace").split("\n"):
+                if not line:
+                    continue
+                base_path = Path(volume) / location
+                full_path = base_path / line
+
+                package_root_dirs.add(base_path)
+                # Only add the base path to dirs to remove if it's Python-specific
+                # Don't add system directories like /usr/local/bin or /Applications
+                base_path_str = str(base_path)
+                if version and ("Python" in base_path_str or version in base_path_str):
+                    all_dirs.add(base_path)
+
+                if full_path.exists():
+                    if full_path.is_file() or full_path.is_symlink():
+                        all_files.add(full_path)
+                    elif full_path.is_dir():
+                        all_dirs.add(full_path)
+
+    return all_files, all_dirs, package_root_dirs
+
+
+def _find_lib_python_files(
+    check_path: Path, major: str, minor: str, abiflags: str
+) -> set[Path]:
+    ignore_files: set[Path] = set()
+    lib_python = check_path / "lib" / f"python{major}.{minor}{abiflags}"
+    site_packages = lib_python / "site-packages"
+    ensurepip_bundled = lib_python / "ensurepip" / "_bundled"
+
+    if site_packages.is_dir():
+        for item in site_packages.glob("*.dist-info"):
+            record_file = item / "RECORD"
+            try:
+                lines = record_file.read_text().splitlines()
+            except Exception as exc:
+                print(f"warning: can't read {record_file}: {exc}")
+                continue
+            for line in lines:
+                if not line.strip():
+                    continue
+                # RECORD format: file,hash,size
+                file_path = line.split(",")[0]
+                if file_path:
+                    if file_path.startswith(".."):
+                        # Handle ../../../pip3 style paths
+                        abs_path = (site_packages / file_path).resolve()
+                    else:
+                        abs_path = site_packages / file_path
+                    ignore_files.add(abs_path)
+                    # Also add the dist-info directory itself
+                    ignore_files.add(item)
+
+    # Also ignore any .whl files in ensurepip/_bundled (upgraded pip wheels)
+    if ensurepip_bundled.is_dir():
+        for whl in ensurepip_bundled.glob("*.whl"):
+            ignore_files.add(whl)
+
+    # Special case: The PythonT framework postinstall script renames pip3 to pip3t
+    # and pip3.X to pip3.Xt, so these files aren't tracked in the wheel's RECORD
+    if abiflags == "t":
+        bin_python = check_path / "bin"
+        if bin_python.exists():
+            for pip_name in (f"pip{major}t", f"pip{major}.{minor}t"):
+                pip_path = bin_python / pip_name
+                if pip_path.exists():
+                    ignore_files.add(pip_path)
+
+    return ignore_files
+
+
+def _check_extra_files(
+    all_files: set[Path], major: str, minor: str, force: bool
+) -> tuple[bool, set[Path]]:
+    """
+    Check for extra files not managed by packages.
+    Returns (OK to proceed, set of acceptable extra files to remove).
+    """
+    extra_files: set[Path] = set()
+    acceptable_extras: set[Path] = set()
+
+    # Find the most specific directories that contain our package files
+    check_dirs: set[Path] = set()
+
+    # Group files by their parent directories to find Python-specific roots
+    version_roots = {f"Python {major}.{minor}", f"{major}.{minor}"}
+    for file_path in all_files:
+        for parent in file_path.parents:
+            if parent.name in version_roots:
+                check_dirs.add(parent)
+                break
+
+    # Build a set of files to ignore: pip-installed packages and ensurepip-related stuff
+    ignore_files: set[Path] = set()
+    for check_path in check_dirs:
+        ignore_files.update(_find_lib_python_files(check_path, major, minor, ""))
+        ignore_files.update(_find_lib_python_files(check_path, major, minor, "t"))
+
+    # Walk these directories and find files not in our package list
+    for check_path in check_dirs:
+        for item in check_path.rglob("*"):
+            # Skip if already known
+            if item in all_files:
+                continue
+
+            if item.is_file() or item.is_symlink():
+                # Safe to remove during installation without a fuss
+                if (
+                    item.suffix == ".pyc"
+                    or item.is_symlink()
+                    or item in ignore_files
+                    or any(
+                        item.is_relative_to(ignored)
+                        for ignored in ignore_files
+                        if ignored.is_dir()
+                    )
+                ):
+                    acceptable_extras.add(item)
+                else:
+                    # Unsafe to delete, will complain later
+                    if not item.is_symlink():
+                        extra_files.add(item)
+
+    if extra_files:
+        cutoff = 1000  # Show first `cutoff` files
+        sorted_extras = sorted(extra_files, key=str)
+        prefix = "" if force else "Error: "
+        print(f"\n{prefix}Found extra files not installed by the package:")
+
+        for file in sorted_extras[:cutoff]:
+            print(f"  - {file}")
+        if len(extra_files) > cutoff:
+            print(f"  ... and {len(extra_files) - cutoff} more")
+        if not force:
+            print(
+                "\nUse --force=true to remove anyway,"
+                " or manually clean up these files first."
+            )
+            return False, set()
+
+    # If force is used, add the problematic extras to acceptable list
+    if force:
+        acceptable_extras.update(extra_files)
+
+    return True, acceptable_extras
+
+
+def _remove_files(
+    all_files: set[Path], dry_run: bool = False
+) -> tuple[set[Path], dict[Path, str]]:
+    """Remove files one by one.
+
+    Returns a two-tuple with (successfully_removed, failed_files). Successfully removed
+    is a set, failed files is a dictionary where paths are keys and exception messages
+    are values.
+    """
+    removed_count = 0
+    failed_files: dict[Path, str] = {}
+    successfully_removed: set[Path] = set()
+
+    for path in sorted(all_files, key=str, reverse=True):  # Remove in reverse order
+        try:
+            if path.exists(follow_symlinks=False):
+                if path.is_symlink() or path.is_file():
+                    if not dry_run:
+                        path.unlink()
+                    removed_count += 1
+                    successfully_removed.add(path)
+        except Exception as e:
+            failed_files[path] = str(e)
+
+    return successfully_removed, failed_files
+
+
+def _remove_directories(
+    all_dirs: set[Path],
+    dry_run: bool = False,
+    *,
+    removed_files: set[Path] | None = None,
+) -> tuple[set[Path], dict[Path, str]]:
+    """Remove directories.
+
+    Returns (removed_dirs, failed_dirs).
+    """
+    removed_dirs: set[Path] = set()
+    removed_files = removed_files or set()
+    failed_dirs: dict[Path, str] = {}
+
+    # Track directories that would be successfully removed
+
+    for path in sorted(all_dirs, key=str, reverse=True):
+        try:
+            if not path.exists():
+                continue
+            if not path.is_dir():
+                continue
+            if dry_run:
+                # In dry run, check if dir would be empty after file/subdir removal
+                remaining_items = [
+                    item
+                    for item in path.iterdir()
+                    if item not in removed_files and item not in removed_dirs
+                ]
+                if not remaining_items:
+                    removed_dirs.add(path)
+                else:
+                    # Check if all remaining items are dirs that will be removed
+                    all_dirs_removed = all(
+                        item in all_dirs and item in removed_dirs
+                        for item in remaining_items
+                        if item.is_dir()
+                    )
+                    all_files_removed = all(
+                        item in removed_files
+                        for item in remaining_items
+                        if item.is_file()
+                    )
+
+                    if all_dirs_removed and all_files_removed:
+                        removed_dirs.add(path)
+                    else:
+                        actual_remaining = [
+                            item
+                            for item in remaining_items
+                            if (item.is_file() and item not in removed_files)
+                            or (item.is_dir() and item not in all_dirs)
+                        ]
+                        if actual_remaining:
+                            remaining_names = ", ".join(
+                                item.name for item in actual_remaining[:5]
+                            )
+                            if len(actual_remaining) > 5:
+                                remaining_names += (
+                                    f", ... and {len(actual_remaining) - 5} more"
+                                )
+                            failed_dirs[path] = f"Files remaining: {remaining_names}"
+                        elif remaining_items:
+                            # There are remaining items but they're all in our removal
+                            # list but haven't been removed yet (processing order issue)
+                            # This should still be counted as a failure
+                            remaining_names = ", ".join(
+                                item.name for item in remaining_items[:5]
+                            )
+                            if len(remaining_items) > 5:
+                                remaining_names += (
+                                    f", ... and {len(remaining_items) - 5} more"
+                                )
+                            failed_dirs[path] = f"Files remaining: {remaining_names}"
+            else:
+                path.rmdir()
+                removed_dirs.add(path)
+        except Exception as e:
+            failed_dirs[path] = str(e)
+
+    return removed_dirs, failed_dirs
+
+
+def _forget_packages(packages: list[str], dry_run: bool = False) -> None:
+    """Forget packages from the system database."""
+    print("\nForgetting packages from system database...")
+    for pkg in packages:
+        if dry_run:
+            print(f"  - Would forget {pkg}")
+        else:
+            result = run(  # noqa: S603
+                ["/usr/sbin/pkgutil", "--forget", pkg],
+                capture_output=True,
+                text=True,
+            )
+            if result.returncode != 0:
+                print(f"Warning: Failed to forget package {pkg}: {result.stderr}")
+            else:
+                print(f"  - Forgot {pkg}")

--- a/src/mopup/__init__.py
+++ b/src/mopup/__init__.py
@@ -431,6 +431,7 @@ def _collect_package_files(
         package_root_dirs.add(base_path)
 
         # Only add the base path to dirs to remove if it's Python-specific
+        # Don't add system directories like /usr/local/bin or /Applications
         base_path_str = str(base_path)
         if version and ("Python" in base_path_str or version in base_path_str):
             all_dirs.add(base_path)
@@ -567,7 +568,6 @@ def _check_extra_files(
             )
             return False, set()
 
-    # If force is used, add the problematic extras to acceptable list
     if force:
         acceptable_extras.update(extra_files)
 
@@ -614,8 +614,6 @@ def _remove_directories(
     removed_dirs: set[Path] = set()
     removed_files = removed_files or set()
     failed_dirs: dict[Path, str] = {}
-
-    # Track directories that would be successfully removed
 
     for path in sorted(all_dirs, key=str, reverse=True):
         try:

--- a/src/mopup/__init__.py
+++ b/src/mopup/__init__.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import collections
 import sys
-import os
+from os import geteuid
 from pathlib import Path
 from platform import mac_ver
 from plistlib import dumps as dumpplist
@@ -69,7 +69,7 @@ def choicechanges(pkgfile: str) -> str:
             setting = int(choice_id in all_installed)
             if setting:
                 print("selecting choice", each["choiceIdentifier"])
-                each["attributesetting"] = setting
+                each["attributeSetting"] = setting
     return dumpplist(dicts).decode()
 
 
@@ -178,7 +178,7 @@ def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> 
 
 def uninstall(
     *,
-    version: str,
+    minor_release_version: str,
     dry_run: bool = False,
     interactive: bool = False,
     force: bool = False,
@@ -186,13 +186,17 @@ def uninstall(
     """
     Uninstall a specific Python version from the system.
 
-    `version` is a string like "3.13". If `dry_run` is True, only show what would be
-    removed without actually removing. If `interactive` is True, ask for confirmation
-    before proceeding. If `force` is True, remove even if extra files are present.
+    `minor_release_version` is a string like "3.13". If `dry_run` is True, only show
+    what would be removed without actually removing. If `interactive` is True, ask for
+    confirmation before proceeding. If `force` is True, remove even if extra files are
+    present.
     """
-    version_parts = version.split(".")
+    version_parts = minor_release_version.split(".")
     if len(version_parts) < 2:
-        print(f"Error: Invalid version format {version!r}. Use format like '3.13'")
+        print(
+            f"Error: Invalid version format {minor_release_version!r}."
+            f" Use format like '3.13'"
+        )
         return
 
     major = version_parts[0]
@@ -201,17 +205,17 @@ def uninstall(
     _ensure_sudo_if_needed(dry_run)
     packages = _find_python_packages(major, minor)
     if not packages:
-        print(f"No Python {version} installation found.")
+        print(f"No Python {minor_release_version} installation found.")
         return
 
-    print(f"Found Python {version} packages:")
+    print(f"Found Python {minor_release_version} packages:")
     for pkg in packages:
         print(f"  - {pkg}")
 
     all_files, all_dirs, package_root_dirs = _collect_package_files(packages)
 
     if not all_files and not all_dirs:
-        print(f"No files found for Python {version}.")
+        print(f"No files found for Python {minor_release_version}.")
         return
 
     ok_to_proceed, acceptable_extras = _check_extra_files(
@@ -275,9 +279,12 @@ def uninstall(
     _forget_packages(packages, dry_run)
 
     if dry_run:
-        print(f"\nDry run complete. Python {version} would be uninstalled.")
+        print(
+            f"\nDry run complete."
+            f" Python {minor_release_version} would be uninstalled."
+        )
     else:
-        print(f"\nPython {version} has been uninstalled.")
+        print(f"\nPython {minor_release_version} has been uninstalled.")
 
 
 def do_download(download_url: DecodedURL) -> str:
@@ -321,7 +328,7 @@ def do_download(download_url: DecodedURL) -> str:
 
 def _ensure_sudo_if_needed(dry_run: bool) -> None:
     """Ensure we have sudo privileges if needed, or relaunch with sudo."""
-    is_root = os.geteuid() == 0
+    is_root = geteuid() == 0
 
     # If not root and not dry_run, relaunch with sudo
     if not is_root and not dry_run:
@@ -340,12 +347,13 @@ def _ensure_sudo_if_needed(dry_run: bool) -> None:
                 sys.exit(1)
 
         # Relaunch ourselves with sudo
-        cmd = ["/usr/bin/sudo", executable] + argv
-        result = run(cmd)  # noqa: S603
+        cmd = ["/usr/bin/sudo", executable, "-BI"] + argv
+        result = run(cmd, cwd="/")  # noqa: S603
 
-        # Kill sudo session after completion
-        run(["/usr/bin/sudo", "-k"])  # noqa: S603
-        sys.exit(result.returncode)
+        if sudo_check.returncode != 0:
+            # Kill sudo session after completion if we enabled it
+            run(["/usr/bin/sudo", "-k"])  # noqa: S603
+            sys.exit(result.returncode)
 
 
 def _find_python_packages(major: str, minor: str) -> list[str]:

--- a/src/mopup/__main__.py
+++ b/src/mopup/__main__.py
@@ -6,11 +6,23 @@ from mopup import main as libmain
 from mopup import uninstall as libuninstall
 
 
-@click.command(
+@click.group(
     help="""
          MOPUp - the (m)ac(O)S (P)ython.org (Up)dater
 
-         Run this program and enter your administrator password to install the
+         Tool for managing Python.org installations on macOS.
+         """
+)
+def main() -> None:
+    """The main group for all Click commands."""
+    pass
+
+
+@main.command(
+    help="""
+         Update Python to the latest version.
+
+         Run this command and enter your administrator password to install the
          most recent version from Python.org that matches your major/minor
          version.
          """
@@ -23,33 +35,53 @@ from mopup import uninstall as libuninstall
     "--minor",
     default=False,
     help="do a minor version upgrade rather than the default (a micro-version)",
+    type=bool,
 )
 @click.option(
     "--dry-run",
     default=False,
     help="don't actually download or install anything even if we're not up to date",
+    type=bool,
+)
+def update(interactive: bool, force: bool, minor: bool, dry_run: bool) -> None:
+    """Update Python to the latest version."""
+    libmain(interactive=interactive, force=force, minor_upgrade=minor, dry_run=dry_run)
+
+
+@main.command(
+    help="""
+         Uninstall a specific Python version.
+
+         Removes all files and packages associated with the specified Python version.
+         """
+)
+@click.argument("version", type=str)
+@click.option(
+    "--dry-run",
+    default=False,
+    help="show what would be removed without actually removing anything",
+    type=bool,
 )
 @click.option(
-    "--uninstall",
-    default=None,
-    help="uninstall a specific Python version (e.g., 3.13)",
-    type=str,
+    "--interactive",
+    default=False,
+    help="ask for confirmation before proceeding",
+    type=bool,
 )
-def main(
-    interactive: bool, force: bool, minor: bool, dry_run: bool, uninstall: str | None
-) -> None:
-    """MOPUp."""
-    if uninstall:
-        libuninstall(
-            minor_release_version=uninstall,
-            dry_run=dry_run,
-            interactive=interactive,
-            force=force,
-        )
-    else:
-        libmain(
-            interactive=interactive, force=force, minor_upgrade=minor, dry_run=dry_run
-        )
+@click.option(
+    "--force",
+    default=False,
+    help="remove even if extra files are present",
+    type=bool,
+)
+def uninstall(version: str, dry_run: bool, interactive: bool, force: bool) -> None:
+    """Uninstall a specific Python version."""
+    libuninstall(
+        minor_release_version=version,
+        dry_run=dry_run,
+        interactive=interactive,
+        force=force,
+    )
 
 
 if __name__ == "__main__":

--- a/src/mopup/__main__.py
+++ b/src/mopup/__main__.py
@@ -3,6 +3,7 @@
 import click
 
 from mopup import main as libmain
+from mopup import uninstall as libuninstall
 
 
 @click.command(
@@ -28,9 +29,24 @@ from mopup import main as libmain
     default=False,
     help="don't actually download or install anything even if we're not up to date",
 )
-def main(interactive: bool, force: bool, minor: bool, dry_run: bool) -> None:
+@click.option(
+    "--uninstall",
+    default=None,
+    help="uninstall a specific Python version (e.g., 3.13)",
+    type=str,
+)
+def main(
+    interactive: bool, force: bool, minor: bool, dry_run: bool, uninstall: str | None
+) -> None:
     """MOPUp."""
-    libmain(interactive=interactive, force=force, minor_upgrade=minor, dry_run=dry_run)
+    if uninstall:
+        libuninstall(
+            version=uninstall, dry_run=dry_run, interactive=interactive, force=force
+        )
+    else:
+        libmain(
+            interactive=interactive, force=force, minor_upgrade=minor, dry_run=dry_run
+        )
 
 
 if __name__ == "__main__":

--- a/src/mopup/__main__.py
+++ b/src/mopup/__main__.py
@@ -41,7 +41,10 @@ def main(
     """MOPUp."""
     if uninstall:
         libuninstall(
-            version=uninstall, dry_run=dry_run, interactive=interactive, force=force
+            minor_release_version=uninstall,
+            dry_run=dry_run,
+            interactive=interactive,
+            force=force,
         )
     else:
         libmain(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,34 @@
+"""Pytest configuration and fixtures."""
+
+from __future__ import annotations
+
+import pytest
+from pytest import Config, Item, Parser
+
+
+def pytest_addoption(parser: Parser) -> None:
+    """Add custom command line options."""
+    parser.addoption(
+        "--destructive",
+        action="store_true",
+        default=False,
+        help="run destructive tests that may modify the system",
+    )
+
+
+def pytest_configure(config: Config) -> None:
+    """Configure pytest with custom markers."""
+    config.addinivalue_line(
+        "markers", "destructive: mark test as making actual changes to the system"
+    )
+
+
+def pytest_collection_modifyitems(config: Config, items: list[Item]) -> None:
+    """Skip destructive tests unless --destructive flag is passed."""
+    if config.getoption("--destructive"):
+        # --destructive given in cli: do not skip destructive tests
+        return
+    skip_destructive = pytest.mark.skip(reason="need --destructive option to run")
+    for item in items:
+        if "destructive" in item.keywords:
+            item.add_marker(skip_destructive)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,7 +14,7 @@ def runner() -> CliRunner:
 
 def test_main_succeeds(runner: CliRunner) -> None:
     """It exits with a status code of zero."""
-    result = runner.invoke(__main__.main, ["--dry-run=true"])
+    result = runner.invoke(__main__.main, ["update", "--dry-run=true"])
     assert result.exit_code == 0
 
 
@@ -25,7 +25,7 @@ def test_uninstall_dry_run(runner: CliRunner) -> None:
 
     version = f"{sys.version_info.major}.{sys.version_info.minor}"
 
-    result = runner.invoke(__main__.main, ["--uninstall", version, "--dry-run=true"])
+    result = runner.invoke(__main__.main, ["uninstall", version, "--dry-run=true"])
     assert result.exit_code == 0
 
     # Check that it found packages
@@ -34,14 +34,14 @@ def test_uninstall_dry_run(runner: CliRunner) -> None:
 
 def test_uninstall_invalid_version(runner: CliRunner) -> None:
     """Test uninstall with invalid version format."""
-    result = runner.invoke(__main__.main, ["--uninstall", "3", "--dry-run=true"])
+    result = runner.invoke(__main__.main, ["uninstall", "3", "--dry-run=true"])
     assert result.exit_code == 0
     assert "Invalid version format" in result.output
 
 
 def test_uninstall_nonexistent_version(runner: CliRunner) -> None:
     """Test uninstall with non-existent Python version."""
-    result = runner.invoke(__main__.main, ["--uninstall", "2.7", "--dry-run=true"])
+    result = runner.invoke(__main__.main, ["uninstall", "2.7", "--dry-run=true"])
     assert result.exit_code == 0
     assert "No Python 2.7 installation found" in result.output
 
@@ -53,7 +53,7 @@ def test_uninstall_with_force(runner: CliRunner) -> None:
     version = f"{sys.version_info.major}.{sys.version_info.minor}"
 
     result = runner.invoke(
-        __main__.main, ["--uninstall", version, "--dry-run=true", "--force=true"]
+        __main__.main, ["uninstall", version, "--dry-run=true", "--force=true"]
     )
     assert result.exit_code == 0
 
@@ -64,7 +64,7 @@ def test_uninstall_with_force(runner: CliRunner) -> None:
 @pytest.mark.destructive
 def test_main_update_real(runner: CliRunner) -> None:
     """Test real update (downloads but doesn't install due to being up-to-date)."""
-    result = runner.invoke(__main__.main)
+    result = runner.invoke(__main__.main, ["update"])
     assert result.exit_code == 0
     # Should find that we're already up-to-date or need an update
     assert "update" in result.output.lower()
@@ -79,7 +79,7 @@ def test_uninstall_interactive(runner: CliRunner) -> None:
 
     # With interactive=true and no actual user input, this should exit cleanly
     result = runner.invoke(
-        __main__.main, ["--uninstall", version, "--interactive=true"], input="no\n"
+        __main__.main, ["uninstall", version, "--interactive=true"], input="no\n"
     )
     assert result.exit_code == 0
     assert "Found Python" in result.output or "No Python" in result.output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -14,5 +14,72 @@ def runner() -> CliRunner:
 
 def test_main_succeeds(runner: CliRunner) -> None:
     """It exits with a status code of zero."""
+    result = runner.invoke(__main__.main, ["--dry-run=true"])
+    assert result.exit_code == 0
+
+
+def test_uninstall_dry_run(runner: CliRunner) -> None:
+    """Test uninstall with dry-run mode."""
+    # Get the current Python version
+    import sys
+
+    version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    result = runner.invoke(__main__.main, ["--uninstall", version, "--dry-run=true"])
+    assert result.exit_code == 0
+
+    # Check that it found packages
+    assert "Found Python" in result.output or "No Python" in result.output
+
+
+def test_uninstall_invalid_version(runner: CliRunner) -> None:
+    """Test uninstall with invalid version format."""
+    result = runner.invoke(__main__.main, ["--uninstall", "3", "--dry-run=true"])
+    assert result.exit_code == 0
+    assert "Invalid version format" in result.output
+
+
+def test_uninstall_nonexistent_version(runner: CliRunner) -> None:
+    """Test uninstall with non-existent Python version."""
+    result = runner.invoke(__main__.main, ["--uninstall", "2.7", "--dry-run=true"])
+    assert result.exit_code == 0
+    assert "No Python 2.7 installation found" in result.output
+
+
+def test_uninstall_with_force(runner: CliRunner) -> None:
+    """Test uninstall with force option in dry-run mode."""
+    import sys
+
+    version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    result = runner.invoke(
+        __main__.main, ["--uninstall", version, "--dry-run=true", "--force=true"]
+    )
+    assert result.exit_code == 0
+
+    # Should complete without errors about extra files
+    assert "Found Python" in result.output or "No Python" in result.output
+
+
+@pytest.mark.destructive
+def test_main_update_real(runner: CliRunner) -> None:
+    """Test real update (downloads but doesn't install due to being up-to-date)."""
     result = runner.invoke(__main__.main)
     assert result.exit_code == 0
+    # Should find that we're already up-to-date or need an update
+    assert "update" in result.output.lower()
+
+
+@pytest.mark.destructive
+def test_uninstall_interactive(runner: CliRunner) -> None:
+    """Test uninstall with interactive mode (won't actually uninstall)."""
+    import sys
+
+    version = f"{sys.version_info.major}.{sys.version_info.minor}"
+
+    # With interactive=true and no actual user input, this should exit cleanly
+    result = runner.invoke(
+        __main__.main, ["--uninstall", version, "--interactive=true"], input="no\n"
+    )
+    assert result.exit_code == 0
+    assert "Found Python" in result.output or "No Python" in result.output

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -12,7 +12,7 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
-def test_main_succeeds(runner: CliRunner) -> None:
+def test_update_dry_run(runner: CliRunner) -> None:
     """It exits with a status code of zero."""
     result = runner.invoke(__main__.main, ["update", "--dry-run=true"])
     assert result.exit_code == 0


### PR DESCRIPTION
This adds the ability to uninstall any[^1] Python.org installation from macOS. It does it safely, i.e. it won't begin if there's unexpected files inside the installation. But it handles the typical weird stuff that happens during Python installation:
- ensurepip and friends
- custom wheels installed globally into site-packages
- .pyc files
- free-threading pip binaries

I also split tests into non-destructive (default) and destructive (don't run by default). Non-destructive tests won't ask you for a sudo password and won't upgrade/uninstall anything. You need to run with the "destructive" marker, or with `nox --session=tests-destructive`, for that to happen. This is enabled on CI.

[^1]: Tested with 3.13 and 3.14 lol. Let's see how CI likes it.