### PR TITLE
Implement `mopup list`

### DIFF
--- a/src/mopup/__init__.py
+++ b/src/mopup/__init__.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import collections
 import json
+import re
 import sys
 from os import geteuid
 from pathlib import Path
@@ -14,7 +15,7 @@ from re import compile as compile_re
 from subprocess import PIPE, run  # noqa: S404
 from sys import argv, executable, version_info
 from tempfile import NamedTemporaryFile
-from typing import Iterable, Match, Pattern
+from typing import cast, Dict, Iterable, Iterator, Match, Pattern, TypedDict
 from uuid import uuid4
 
 import html5lib
@@ -22,6 +23,33 @@ import requests
 from hyperlink import DecodedURL
 from packaging.version import Version, parse
 from rich.progress import Progress
+
+
+PKG_RE = re.compile(r"^org\.python\.Python\.(?P<name>.*)-(?P<version>\d+\.\d+)$")
+
+PkgFileInfo = TypedDict(
+    "PkgFileInfo",
+    {
+        "pkgid": "str",
+        "pkg-version": "str",
+        "uid": int,
+        "gid": int,
+        "mode": int,
+        "install-time": int,
+    },
+)
+PkgInfo = TypedDict(
+    "PkgInfo",
+    {
+        "pkgid": "str",
+        "pkg-version": "str",
+        "volume": "str",
+        "install-location": "str",
+        "paths": Dict[str, PkgFileInfo],
+        "install-time": int,
+        "receipt-plist-version": int,
+    },
+)
 
 
 def alllinksin(
@@ -141,9 +169,7 @@ def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> 
 
     best_ver, download_url = sorted(download_urls, reverse=True)[0]
 
-    # TODO: somehow flake8 in pre-commit thinks that this semicolon is in the
-    # *code* and not in a string.
-    print(f"this version: {thispkgver}; new version: {best_ver}")  # noqa
+    print(f"this version: {thispkgver}; new version: {best_ver}")
     update_needed = best_ver > thispkgver
 
     print(
@@ -177,6 +203,52 @@ def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> 
     print("Complete.")
 
 
+def list_installed() -> None:
+    """List all Python versions installed with official Python.org installers."""
+    version_executables: list[tuple[Version, str, Path]] = []
+    for pkg, _short_name, version in _find_python_packages():
+        try:
+            plist_data = _get_package_metadata_json(pkg)
+        except Exception as e:
+            print(f"Warning: {e}")
+            continue
+
+        location = plist_data.get("install-location", "")
+        volume = plist_data.get("volume", "/")
+        paths = plist_data.get("paths", {})
+        if not location:
+            continue
+
+        base_path = Path(volume) / location
+        exe_paths = [
+            f"Versions/{version}/bin/python{version}t",
+            f"Versions/{version}/bin/python{version}",
+        ]
+        for exe_path in exe_paths:
+            exe_meta = paths.get(exe_path, _empty_pkgfileinfo(pkg))
+            is_executable = exe_meta.get("mode", 0) & 0o111
+            if is_executable:
+                version_executables.append((version, pkg, base_path / exe_path))
+                break
+
+    version_executables.sort()
+
+    for version, pkg, python_exe in version_executables:
+        exact_version = None
+        if python_exe.is_file():
+            version_result = run(  # noqa: S603
+                [str(python_exe), "-c", "import sys; print(sys.version)"],
+                capture_output=True,
+                text=True,
+            )
+            if version_result.returncode == 0:
+                exact_version = version_result.stdout.split(" ", 1)[0]
+        if exact_version:
+            print(f"{exact_version:<12}{pkg:<44}{python_exe}")
+        else:
+            print(f"{version:<12}{pkg:<44}")
+
+
 def uninstall(
     *,
     minor_release_version: str,
@@ -192,19 +264,12 @@ def uninstall(
     confirmation before proceeding. If `force` is True, remove even if extra files are
     present.
     """
-    version_parts = minor_release_version.split(".")
-    if len(version_parts) < 2:
-        print(
-            f"Error: Invalid version format {minor_release_version!r}."
-            f" Use format like '3.13'"
-        )
-        return
-
-    major = version_parts[0]
-    minor = version_parts[1]
-
     _ensure_sudo_if_needed(dry_run)
-    packages = _find_python_packages(major, minor)
+    version = Version(minor_release_version)
+
+    packages = []
+    packages = [p[0] for p in _find_python_packages(version)]
+
     if not packages:
         print(f"No Python {minor_release_version} installation found.")
         return
@@ -219,9 +284,7 @@ def uninstall(
         print(f"No files found for Python {minor_release_version}.")
         return
 
-    ok_to_proceed, acceptable_extras = _check_extra_files(
-        all_files, major, minor, force
-    )
+    ok_to_proceed, acceptable_extras = _check_extra_files(all_files, version, force)
     if not ok_to_proceed:
         return
 
@@ -357,21 +420,70 @@ def _ensure_sudo_if_needed(dry_run: bool) -> None:
             sys.exit(result.returncode)
 
 
-def _find_python_packages(major: str, minor: str) -> list[str]:
-    """Find all Python packages for a specific version."""
+def _get_package_metadata_json(pkg: str) -> PkgInfo:
+    """
+    Get package metadata as JSON dictionary.
+
+    Raises an exception if the package metadata cannot be retrieved or parsed.
+    """
+    # Export package info as plist
+    plist_result = run(  # noqa: S603
+        ["/usr/sbin/pkgutil", "--export-plist", pkg],
+        capture_output=True,
+    )
+
+    if plist_result.returncode != 0:
+        error_msg = (
+            plist_result.stderr.decode() if plist_result.stderr else "Unknown error"
+        )
+        raise RuntimeError(f"Failed to get pkgutil plist for {pkg}: {error_msg}")
+
+    # Convert plist XML to JSON using plutil
+    json_result = run(  # noqa: S603
+        ["/usr/bin/plutil", "-convert", "json", "-o", "-", "-"],
+        input=plist_result.stdout,
+        capture_output=True,
+    )
+
+    if json_result.returncode != 0:
+        error_msg = (
+            json_result.stderr.decode() if json_result.stderr else "Unknown error"
+        )
+        raise RuntimeError(f"Failed to convert plist to JSON for {pkg}: {error_msg}")
+
+    return cast(PkgInfo, json.loads(json_result.stdout))
+
+
+def _find_python_packages(
+    version: Version | None = None,
+) -> Iterator[tuple[str, str, Version]]:
+    """Generate (full pkg name, short name, version) for installed Pythons.
+
+    If `version` is given, only the packages matching that version will be returned.
+    """
+
+    if version is not None:
+        if len(version.release) != 2 or version.pre or version.post:
+            raise ValueError(
+                f"Invalid version '{version}', expected 'major.minor' (like '3.13')"  # noqa: B907
+            )
+
     result = run(  # noqa: S603
         ["/usr/sbin/pkgutil", "--pkgs"],
         stdout=PIPE,
         text=True,
     )
 
-    packages = [
-        pkg
-        for pkg in result.stdout.strip().split("\n")
-        if pkg.startswith("org.python.Python.") and pkg.endswith(f"-{major}.{minor}")
-    ]
+    if result.returncode != 0:
+        error_msg = result.stderr if result.stderr else "Unknown error"
+        raise RuntimeError(f"Failed to list packages with pkgutil: {error_msg}")
 
-    return packages
+    for pkg in result.stdout.strip().split("\n"):
+        if match := PKG_RE.match(pkg):
+            short_name = match["name"]
+            actual_version = Version(match["version"])
+            if version is None or version == actual_version:
+                yield pkg, short_name, actual_version
 
 
 def _collect_package_files(
@@ -390,34 +502,10 @@ def _collect_package_files(
             break
 
     for pkg in packages:
-        # Export package info as plist and convert to JSON to preserve \r characters
-        # (plistlib's XML parsing normalizes \r to \n, but JSON preserves them)
-        plist_result = run(  # noqa: S603
-            ["/usr/sbin/pkgutil", "--export-plist", pkg],
-            capture_output=True,
-        )
-
-        if plist_result.returncode != 0:
-            print(f"Warning: Failed to get pkgutil plist for {pkg}", end="")
-            print(f":{err.decode()}" if (err := plist_result.stderr) else "")
-            continue
-
-        # Convert plist XML to JSON using plutil
-        json_result = run(  # noqa: S603
-            ["/usr/bin/plutil", "-convert", "json", "-o", "-", "-"],
-            input=plist_result.stdout,
-            capture_output=True,
-        )
-
-        if json_result.returncode != 0:
-            print(f"Warning: Failed to convert plist to JSON for {pkg}", end="")
-            print(f":{err.decode()}" if (err := plist_result.stderr) else "")
-            continue
-
         try:
-            plist_data = json.loads(json_result.stdout)
+            plist_data = _get_package_metadata_json(pkg)
         except Exception as e:
-            print(f"Warning: Failed to parse JSON for {pkg}: {e}")
+            print(f"Warning: {e}")
             continue
 
         # Get install location and volume
@@ -451,10 +539,10 @@ def _collect_package_files(
 
 
 def _find_lib_python_files(
-    check_path: Path, major: str, minor: str, abiflags: str
+    check_path: Path, version: Version, abiflags: str
 ) -> set[Path]:
     ignore_files: set[Path] = set()
-    lib_python = check_path / "lib" / f"python{major}.{minor}{abiflags}"
+    lib_python = check_path / "lib" / f"python{version}{abiflags}"
     site_packages = lib_python / "site-packages"
     ensurepip_bundled = lib_python / "ensurepip" / "_bundled"
 
@@ -491,7 +579,7 @@ def _find_lib_python_files(
     if abiflags == "t":
         bin_python = check_path / "bin"
         if bin_python.exists():
-            for pip_name in (f"pip{major}t", f"pip{major}.{minor}t"):
+            for pip_name in (f"pip{version.major}t", f"pip{version}t"):
                 pip_path = bin_python / pip_name
                 if pip_path.exists():
                     ignore_files.add(pip_path)
@@ -500,7 +588,7 @@ def _find_lib_python_files(
 
 
 def _check_extra_files(
-    all_files: set[Path], major: str, minor: str, force: bool
+    all_files: set[Path], version: Version, force: bool
 ) -> tuple[bool, set[Path]]:
     """
     Check for extra files not managed by packages.
@@ -513,7 +601,7 @@ def _check_extra_files(
     check_dirs: set[Path] = set()
 
     # Group files by their parent directories to find Python-specific roots
-    version_roots = {f"Python {major}.{minor}", f"{major}.{minor}"}
+    version_roots = {f"Python {version}", str(version)}
     for file_path in all_files:
         for parent in file_path.parents:
             if parent.name in version_roots:
@@ -523,8 +611,8 @@ def _check_extra_files(
     # Build a set of files to ignore: pip-installed packages and ensurepip-related stuff
     ignore_files: set[Path] = set()
     for check_path in check_dirs:
-        ignore_files.update(_find_lib_python_files(check_path, major, minor, ""))
-        ignore_files.update(_find_lib_python_files(check_path, major, minor, "t"))
+        ignore_files.update(_find_lib_python_files(check_path, version, ""))
+        ignore_files.update(_find_lib_python_files(check_path, version, "t"))
 
     # Walk these directories and find files not in our package list
     for check_path in check_dirs:
@@ -698,3 +786,14 @@ def _forget_packages(packages: list[str], dry_run: bool = False) -> None:
                 print(f"Warning: Failed to forget package {pkg}: {result.stderr}")
             else:
                 print(f"  - Forgot {pkg}")
+
+
+def _empty_pkgfileinfo(pkgid: str, install_time: int = 0) -> PkgFileInfo:
+    return {
+        "pkgid": pkgid,
+        "pkg-version": "0",
+        "uid": 0,
+        "gid": 0,
+        "mode": 0,
+        "install-time": install_time,
+    }

--- a/src/mopup/__init__.py
+++ b/src/mopup/__init__.py
@@ -7,6 +7,7 @@ import json
 import re
 import sys
 from os import geteuid
+from os.path import lexists  # Path.exists(follow_symlinks=False) was only added in 3.12
 from pathlib import Path
 from platform import mac_ver
 from plistlib import dumps as dumpplist
@@ -677,7 +678,7 @@ def _remove_files(
 
     for path in sorted(all_files, key=str, reverse=True):  # Remove in reverse order
         try:
-            if path.exists(follow_symlinks=False):
+            if lexists(path):
                 if path.is_symlink() or path.is_file():
                     if not dry_run:
                         path.unlink()

--- a/src/mopup/__init__.py
+++ b/src/mopup/__init__.py
@@ -53,6 +53,10 @@ PkgInfo = TypedDict(
 )
 
 
+class MOPUpValueError(ValueError):
+    """Deliberate application-specific value errors."""
+
+
 def alllinksin(
     u: DecodedURL, e: Pattern[str]
 ) -> Iterable[tuple[Match[str], DecodedURL]]:
@@ -103,7 +107,13 @@ def choicechanges(pkgfile: str) -> str:
     return dumpplist(dicts).decode()
 
 
-def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> None:
+def main(
+    target_version: str | None,
+    interactive: bool,
+    force: bool,
+    minor_upgrade: bool,
+    dry_run: bool,
+) -> None:
     """Do an update."""
     _ensure_sudo_if_needed(dry_run)
 
@@ -111,17 +121,40 @@ def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> 
     ver = compile_re(r"(\d+)\.(\d+).(\d+)/")
     macpkg = compile_re(r"python-(\d+\.\d+\.\d+(?:(?:a|b|rc)\d+)?)-macosx?(\d+).pkg")
 
-    thismajor, thisminor, thismicro, releaselevel, serial = version_info
-    level = {
-        "alpha": "a",
-        "beta": "b",
-        "candidate": "rc",
-        "final": "",
-    }[releaselevel]
+    if target_version:
+        target_ver = Version(target_version)
+        for pkg, _short_name, version in _find_python_packages(target_ver):
+            try:
+                python_exe = _get_python_executable(pkg, version)
+                exact_version_str = _get_exact_version(python_exe)
+                if exact_version_str:
+                    thispkgver = Version(exact_version_str)
+                    break
+            except LookupError:
+                continue  # not every Python package contains executables
+            except Exception as e:
+                print(f"Warning: {e}")
+                continue
+        else:
+            raise RuntimeError(f"No Python {target_version} installation found")
 
-    thispkgver = Version(
-        f"{thismajor}.{thisminor}.{thismicro}" + (f".{level}{serial}" if level else "")
-    )
+        thismajor = target_ver.major
+        thisminor = target_ver.minor
+        thismicro = thispkgver.micro or 0
+    else:
+        # Auto-detect from current Python
+        thismajor, thisminor, thismicro, releaselevel, serial = version_info
+        level = {
+            "alpha": "a",
+            "beta": "b",
+            "candidate": "rc",
+            "final": "",
+        }[releaselevel]
+
+        thispkgver = Version(
+            f"{thismajor}.{thisminor}.{thismicro}"
+            + (f".{level}{serial}" if level else "")
+        )
 
     # {macos, major, minor: [(Version, URL)]}
     # major, minor, micro, macos: [(version, URL)]
@@ -204,49 +237,74 @@ def main(interactive: bool, force: bool, minor_upgrade: bool, dry_run: bool) -> 
     print("Complete.")
 
 
+def _get_python_executable(pkg: str, version: Version) -> Path:
+    """Get the Python executable path for a package.
+
+    Raises RuntimeError if the executable cannot be found.
+    """
+    plist_data = _get_package_metadata_json(pkg)
+
+    location = plist_data.get("install-location", "")
+    volume = plist_data.get("volume", "/")
+    paths = plist_data.get("paths", {})
+    if not location:
+        raise MOPUpValueError(f"No install location found for {pkg}")
+
+    base_path = Path(volume) / location
+    exe_paths = [
+        f"Versions/{version}/bin/python{version}t",
+        f"Versions/{version}/bin/python{version}",
+    ]
+    for exe_path in exe_paths:
+        exe_meta = paths.get(exe_path, _empty_pkgfileinfo(pkg))
+        is_executable = exe_meta.get("mode", 0) & 0o111
+        if is_executable:
+            return base_path / exe_path
+
+    raise LookupError(f"No Python executable found for {pkg}")
+
+
+def _get_exact_version(python_exe: Path) -> str:
+    """Get the exact version string from a Python executable.
+
+    Raises RuntimeError if the version cannot be determined.
+    """
+    if not python_exe.is_file():
+        raise RuntimeError(f"Python executable not found: {python_exe}")
+
+    version_result = run(  # noqa: S603
+        [str(python_exe), "-c", "import sys; print(sys.version)"],
+        capture_output=True,
+        text=True,
+    )
+    if version_result.returncode != 0:
+        raise RuntimeError(
+            f"Failed to get version from {python_exe}: {version_result.stderr}"
+        )
+
+    return version_result.stdout.split(" ", 1)[0]
+
+
 def list_installed() -> None:
     """List all Python versions installed with official Python.org installers."""
     version_executables: list[tuple[Version, str, Path]] = []
     for pkg, _short_name, version in _find_python_packages():
         try:
-            plist_data = _get_package_metadata_json(pkg)
+            python_exe = _get_python_executable(pkg, version)
+            version_executables.append((version, pkg, python_exe))
+        except LookupError:
+            continue  # not every Python package contains executables
         except Exception as e:
             print(f"Warning: {e}")
             continue
 
-        location = plist_data.get("install-location", "")
-        volume = plist_data.get("volume", "/")
-        paths = plist_data.get("paths", {})
-        if not location:
-            continue
-
-        base_path = Path(volume) / location
-        exe_paths = [
-            f"Versions/{version}/bin/python{version}t",
-            f"Versions/{version}/bin/python{version}",
-        ]
-        for exe_path in exe_paths:
-            exe_meta = paths.get(exe_path, _empty_pkgfileinfo(pkg))
-            is_executable = exe_meta.get("mode", 0) & 0o111
-            if is_executable:
-                version_executables.append((version, pkg, base_path / exe_path))
-                break
-
     version_executables.sort()
 
     for version, pkg, python_exe in version_executables:
-        exact_version = None
-        if python_exe.is_file():
-            version_result = run(  # noqa: S603
-                [str(python_exe), "-c", "import sys; print(sys.version)"],
-                capture_output=True,
-                text=True,
-            )
-            if version_result.returncode == 0:
-                exact_version = version_result.stdout.split(" ", 1)[0]
-        if exact_version:
+        try:
+            exact_version = _get_exact_version(python_exe)
             print(f"{exact_version:<12}{pkg:<44}{python_exe}")
-        else:
+        except Exception:
             print(f"{version:<12}{pkg:<44}")
 
 
@@ -465,7 +523,7 @@ def _find_python_packages(
 
     if version is not None:
         if len(version.release) != 2 or version.pre or version.post:
-            raise ValueError(
+            raise MOPUpValueError(
                 f"Invalid version '{version}', expected 'major.minor' (like '3.13')"  # noqa: B907
             )
 

--- a/src/mopup/__init__.py
+++ b/src/mopup/__init__.py
@@ -54,7 +54,11 @@ PkgInfo = TypedDict(
 
 
 class MOPUpValueError(ValueError):
-    """Deliberate application-specific value errors."""
+    """Deliberate application-specific value errors. Some value was unexpected."""
+
+
+class MOPUpLookupError(LookupError):
+    """Deliberate application-specific lookup errors. Something wasn't found."""
 
 
 def alllinksin(
@@ -130,7 +134,7 @@ def main(
                 if exact_version_str:
                     thispkgver = Version(exact_version_str)
                     break
-            except LookupError:
+            except MOPUpLookupError:
                 continue  # not every Python package contains executables
             except Exception as e:
                 print(f"Warning: {e}")
@@ -261,7 +265,7 @@ def _get_python_executable(pkg: str, version: Version) -> Path:
         if is_executable:
             return base_path / exe_path
 
-    raise LookupError(f"No Python executable found for {pkg}")
+    raise MOPUpLookupError(f"No Python executable found for {pkg}")
 
 
 def _get_exact_version(python_exe: Path) -> str:
@@ -292,7 +296,7 @@ def list_installed() -> None:
         try:
             python_exe = _get_python_executable(pkg, version)
             version_executables.append((version, pkg, python_exe))
-        except LookupError:
+        except MOPUpLookupError:
             continue  # not every Python package contains executables
         except Exception as e:
             print(f"Warning: {e}")

--- a/src/mopup/__main__.py
+++ b/src/mopup/__main__.py
@@ -4,6 +4,7 @@ import sys
 
 import click
 
+from mopup import MOPUpValueError
 from mopup import list_installed as liblist
 from mopup import main as libmain
 from mopup import uninstall as libuninstall
@@ -28,8 +29,12 @@ def main() -> None:
          Run this command and enter your administrator password to install the
          most recent version from Python.org that matches your major/minor
          version.
+
+         Optionally specify a VERSION (e.g., '3.13') to update a specific Python
+         installation instead of auto-detecting the current version.
          """
 )
+@click.argument("version", required=False, type=str)
 @click.option("--interactive", default=False, help="use the installer GUI", type=bool)
 @click.option(
     "--force", default=False, help="reinstall python even if it's up to date", type=bool
@@ -46,9 +51,22 @@ def main() -> None:
     help="don't actually download or install anything even if we're not up to date",
     type=bool,
 )
-def update(interactive: bool, force: bool, minor: bool, dry_run: bool) -> None:
+def update(
+    version: str | None, interactive: bool, force: bool, minor: bool, dry_run: bool
+) -> None:
     """Update Python to the latest version."""
-    libmain(interactive=interactive, force=force, minor_upgrade=minor, dry_run=dry_run)
+    try:
+        libmain(
+            target_version=version,
+            interactive=interactive,
+            force=force,
+            minor_upgrade=minor,
+            dry_run=dry_run,
+        )
+    except RuntimeError as rexc:
+        print(rexc, file=sys.stderr)
+    except MOPUpValueError as vexc:
+        print(vexc, file=sys.stderr)
 
 
 @main.command(
@@ -64,6 +82,8 @@ def list() -> None:
         liblist()
     except RuntimeError as rexc:
         print(rexc, file=sys.stderr)
+    except MOPUpValueError as vexc:
+        print(vexc, file=sys.stderr)
 
 
 @main.command(
@@ -103,9 +123,7 @@ def uninstall(version: str, dry_run: bool, interactive: bool, force: bool) -> No
         )
     except RuntimeError as rexc:
         print(rexc, file=sys.stderr)
-    except ValueError as vexc:
-        if not str(vexc).startswith("Invalid version"):
-            raise
+    except MOPUpValueError as vexc:
         print(vexc, file=sys.stderr)
 
 

--- a/src/mopup/__main__.py
+++ b/src/mopup/__main__.py
@@ -1,7 +1,10 @@
 """Command-line interface."""
 
+import sys
+
 import click
 
+from mopup import list_installed as liblist
 from mopup import main as libmain
 from mopup import uninstall as libuninstall
 
@@ -50,6 +53,21 @@ def update(interactive: bool, force: bool, minor: bool, dry_run: bool) -> None:
 
 @main.command(
     help="""
+         List all Python versions installed with official Python.org installers.
+
+         Shows the exact versions of Python installed on the system.
+         """
+)
+def list() -> None:
+    """List all Python installations."""
+    try:
+        liblist()
+    except RuntimeError as rexc:
+        print(rexc, file=sys.stderr)
+
+
+@main.command(
+    help="""
          Uninstall a specific Python version.
 
          Removes all files and packages associated with the specified Python version.
@@ -76,12 +94,19 @@ def update(interactive: bool, force: bool, minor: bool, dry_run: bool) -> None:
 )
 def uninstall(version: str, dry_run: bool, interactive: bool, force: bool) -> None:
     """Uninstall a specific Python version."""
-    libuninstall(
-        minor_release_version=version,
-        dry_run=dry_run,
-        interactive=interactive,
-        force=force,
-    )
+    try:
+        libuninstall(
+            minor_release_version=version,
+            dry_run=dry_run,
+            interactive=interactive,
+            force=force,
+        )
+    except RuntimeError as rexc:
+        print(rexc, file=sys.stderr)
+    except ValueError as vexc:
+        if not str(vexc).startswith("Invalid version"):
+            raise
+        print(vexc, file=sys.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,6 +18,46 @@ def test_update_dry_run(runner: CliRunner) -> None:
     assert result.exit_code == 0
 
 
+def test_list(runner: CliRunner) -> None:
+    """Test list command."""
+    result = runner.invoke(__main__.main, ["list"])
+    assert result.exit_code == 0
+
+    # Parse the output - each line should have 3 columns:
+    # version (left-aligned, 12 chars), package (left-aligned, 44 chars), path
+    lines = result.output.strip().split("\n")
+
+    # Filter out warning lines that start with "Warning:"
+    data_lines = [line for line in lines if line and not line.startswith("Warning:")]
+
+    if data_lines:
+        # Verify the structure of each line
+        for line in data_lines:
+            # Check that we have at least 56 characters (12 + 44 for the first two cols)
+            assert len(line) >= 56, f"Line too short: {line}"
+
+            # Extract the three columns
+            version = line[:12].strip()
+            package = line[12:56].strip()
+            path = line[56:].strip() if len(line) > 56 else ""
+
+            # Validate version format (e.g., "3.13.7" or "3.14.0rc2")
+            assert version, f"Missing version in line: {line}"
+            # Version should start with a digit
+            assert version[0].isdigit(), f"Invalid version format: {version}"
+
+            # Validate package name format
+            assert package.startswith(
+                "org.python.Python."
+            ), f"Invalid package name: {package}"
+            assert "-" in package, f"Package missing version suffix: {package}"
+
+            # If there's a path, validate it
+            if path:
+                assert path.startswith("/"), f"Path should be absolute: {path}"
+                assert "python" in path.lower(), f"Path should contain 'python': {path}"
+
+
 def test_uninstall_dry_run(runner: CliRunner) -> None:
     """Test uninstall with dry-run mode."""
     # Get the current Python version
@@ -36,7 +76,7 @@ def test_uninstall_invalid_version(runner: CliRunner) -> None:
     """Test uninstall with invalid version format."""
     result = runner.invoke(__main__.main, ["uninstall", "3", "--dry-run=true"])
     assert result.exit_code == 0
-    assert "Invalid version format" in result.output
+    assert "Invalid version '3'" in result.output
 
 
 def test_uninstall_nonexistent_version(runner: CliRunner) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,6 +18,36 @@ def test_update_dry_run(runner: CliRunner) -> None:
     assert result.exit_code == 0
 
 
+def test_update_specific_version_dry_run(runner: CliRunner) -> None:
+    """Test updating a specific Python version."""
+    import sys
+
+    # Try to update the current Python version specifically
+    version = f"{sys.version_info.major}.{sys.version_info.minor}"
+    result = runner.invoke(__main__.main, ["update", version, "--dry-run=true"])
+    assert result.exit_code == 0
+
+    # Check that it detected the version and checked for updates
+    assert "this version:" in result.output.lower()
+    assert "new version:" in result.output.lower()
+    assert "update" in result.output.lower()
+
+
+def test_update_nonexistent_version(runner: CliRunner) -> None:
+    """Test updating a non-existent Python version."""
+    # Use a version that's very unlikely to be installed
+    result = runner.invoke(__main__.main, ["update", "2.7", "--dry-run=true"])
+    assert result.exit_code == 0
+    assert "No Python 2.7 installation found" in result.output
+
+
+def test_update_invalid_version_format(runner: CliRunner) -> None:
+    """Test updating with invalid version format."""
+    result = runner.invoke(__main__.main, ["update", "3", "--dry-run=true"])
+    assert result.exit_code == 0
+    assert "Invalid version" in result.output
+
+
 def test_list(runner: CliRunner) -> None:
     """Test list command."""
     result = runner.invoke(__main__.main, ["list"])


### PR DESCRIPTION
This does two things:
- allows users to lists, which Python.org installations we're seeing;
- pass a version to `mopup update` to update that version on the machine even if `mopup` is installed on a different Python.
